### PR TITLE
config_replacer: add key_settings support

### DIFF
--- a/py_scripts/ImageGeneration/config_replacer.py
+++ b/py_scripts/ImageGeneration/config_replacer.py
@@ -1,50 +1,105 @@
-import xml.etree.ElementTree as ET
+# SPDX-License-Identifier: GPL-2.0
+#
+# Nuvoton IGPS: Image Generation And Programming Scripts For Arbel BMC
+#
+# Copyright (C) 2022 Nuvoton Technologies, All Rights Reserved
+#-------------------------------------------------------------------------
+
+"""
+Usage:
+    python config_replacer.py settings.json
+    Please note the working directory should be the root of the project.
+    example:
+        python py_scripts/ImageGeneration/config_replacer.py py_scripts/ImageGeneration/inputs/settings.json
+Test:
+    python py_scripts/ImageGeneration/test_config_replacer.py
+
+This script is used for replacing the settings in the XML and Python files from Openbmc setting file.
+It would be useful to reduce effort of maintaining full XML for each configuration.
+"""
+
+from itertools import chain
+
+import configparser
+import io
 import json
 import os
+import sys
+import xml.etree.ElementTree as ET
 
-XML_PATH = os.path.join("py_scripts","ImageGeneration","inputs")
-SETTING_FILE =  os.path.join(XML_PATH, "settings.json")
+XML_PATH = os.path.join("py_scripts", "ImageGeneration", "inputs")
+KEY_SETTINGS_PATH = os.path.join("py_scripts", "ImageGeneration")
+SETTING_FILE = os.path.join(XML_PATH, "settings.json")
 
-"""
-This function loads the settings file and checks if the file exists and is not empty
-@param file: the settings file to load
-@throws ValueError: if the file doesn't exist or is empty
 
-@return: the settings dictionary
-example of the settings file:
-{
-    "BootBlockAndHeader.xml":
+def load_settings(file: str = SETTING_FILE) -> dict[str, dict[str, str]]:
+    """
+    Loads the settings file and checks if the file exists and is not empty.
+
+    Args:
+        file (str): The settings file to load. Defaults to SETTING_FILE.
+
+    Raises:
+        FileNotFoundError: If the file doesn't exist.
+        ValueError: If the file format is invalid.
+
+    Returns:
+        dict[str, dict[str, str]]: The settings dictionary.
+
+    Example of the settings file:
     {
-        "MC_CONFIG": "0x05"
+        "BootBlockAndHeader.xml":
+        {
+            "MC_CONFIG": "0x05"
+        }
     }
-}
-"""
-def load_settings(file = SETTING_FILE):
+    """
     if os.path.isfile(file) == False:
-        raise ValueError(f"Error: {file} doesn't exist")
+        raise FileNotFoundError(f"Error: {file} doesn't exist")
+    # we should accept empty settings file or {} as valid
+    settings = {}
     with open(file) as f:
-        settings = json.load(f)
-    if settings is None:
-        raise ValueError("Error: settings file is empty")
-    # check key (file) is valid
-    for key in settings.keys():
-        if os.path.isfile(os.path.join(XML_PATH, key)) == False:
-            raise ValueError(f"Error: file {key} doesn't exist")
+        data = f.read().strip()
+        if len(data) > 0:
+            settings = json.loads(data)
+    # check settings format
+    for config, values in settings.items():
+        if not isinstance(values, dict):
+            raise ValueError(f"Error: Invalid format in settings file for {config}")
+        for key, value in values.items():
+            if not isinstance(key, str) or not isinstance(value, str):
+                raise ValueError(f"Error: Invalid format in settings file for {config}")
+    print("Settings format is valid")
     return settings
 
-def replace_value_in_xml(xml_file, dict, target_xml = None):
+
+def replace_value_in_xml(xml_file: str, dict: dict[str, str], target_xml: str = None):
+    """
+    Replaces the values in the specified XML file with the given dictionary.
+
+    Args:
+        xml_file (str): The path to the XML file.
+        dict (dict[str, str]): The dictionary containing the tag-value pairs to replace.
+        target_xml (str, optional): The path to the target XML file. If not provided, the original XML file will be overwritten.
+
+    Raises:
+        ValueError: If a tag is not found in the XML file.
+
+    Example:
+        replace_value_in_xml("input.xml", {"TAG1": "VALUE1", "TAG2": "VALUE2"}, "output.xml")
+    """
     tree = ET.parse(xml_file)
     root = tree.getroot()
     # we only interested in the BinField elements
-    elements = root.findall('BinField')
+    elements = root.findall("BinField")
     # replace all the value pairs we defined
     for tag, value in dict.items():
         # search all the elements
         search_count = 0
         for element in elements:
-            e = element.find('name')
+            e = element.find("name")
             if e is not None and e.text is not None and e.text == tag:
-                c = element.find('content')
+                c = element.find("content")
                 if c is None:
                     raise ValueError(f"Error: {tag} has no content")
                 print(f"replacing {tag} value {c.text} to {value}")
@@ -61,15 +116,112 @@ def replace_value_in_xml(xml_file, dict, target_xml = None):
         tree.write(xml_file)
         pass
 
+
+class NoSectionConfigParser:
+    """
+    Hacks class for ConfigParser to avoid read/write section in the configuration file.
+    """
+
+    def __init__(self):
+        self._cp = configparser.RawConfigParser()
+        self._cp.optionxform = lambda option: option
+
+    def read(self, file: str):
+        with open(file) as lines:
+            lines = chain(("[DEFAULT]",), lines)
+            self._cp.read_file(lines)
+            return self._cp.defaults()
+
+    def write(self, file: str):
+        data = io.StringIO()
+        self._cp.write(data)
+        with open(file, "w") as f:
+            f.write(data.getvalue().removeprefix("[DEFAULT]\n"))
+
+    def set(self, key: str, value: str):
+        dict = self._cp["DEFAULT"]
+        if key not in dict:
+            raise ValueError(f"Error: {key} not found in the configuration file")
+        print(f"replacing {key} value {dict[key]} to {value}")
+        dict[key] = value
+
+
+def replace_value_in_py(py_file: str, dict: dict[str, str], target_py: str = None):
+    """
+    Replaces the values in the specified Python file with the given dictionary.
+
+    Args:
+        py_file (str): The path to the Python file.
+        dict (dict[str, str]): The dictionary containing the key-value pairs to replace.
+        target_py (str, optional): The path to the target Python file. If not provided, the original Python file will be overwritten.
+
+    Raises:
+        ValueError: If a key is not found in the configuration file.
+
+    Example:
+        replace_value_in_py("script.py", {"KEY1": "VALUE1", "KEY2": "VALUE2"}, "output.py")
+    """
+    cp = NoSectionConfigParser()
+    cp.read(py_file)
+    for key, value in dict.items():
+        cp.set(key, value)
+    if target_py is not None:
+        cp.write(target_py)
+    else:
+        cp.write(py_file)
+
+
+def replace_settings_test(file: str):
+    # test the function, save results to the test folder
+    settings = load_settings(file=file)
+    for config in settings.keys():
+        if config.endswith(".xml"):
+            replace_value_in_xml(
+                os.path.join(XML_PATH, config),
+                settings[config],
+                os.path.join("test", config),
+            )
+        elif config.endswith(".py"):
+            replace_value_in_py(
+                os.path.join(KEY_SETTINGS_PATH, config),
+                settings[config],
+                os.path.join("test", config),
+            )
+        else:
+            raise ValueError(f"Error: {config} is not a supported configuration")
+
+def change_pwd_to_script_root() -> tuple[str, str]:
+    # change the working directory to the root of the project
+    root = "py_scripts"
+    pwd = os.getcwd()
+    # search from cwd
+    if os.path.exists(root):
+        return pwd, pwd
+    if root in pwd:
+        target_pwd = pwd[:pwd.index(root)]
+    # search from the script path
+    elif root in __file__:
+        target_pwd = __file__[:__file__.index(root)]
+    else:
+        raise FileNotFoundError(f"Error: {root} not found in the path")
+    os.chdir(target_pwd)
+    print (f"Working directory: {target_pwd}")
+    return target_pwd, pwd
+
 if __name__ == "__main__":
-    # do nothing if the settings file doesn't exist
-    if os.path.isfile(SETTING_FILE) == False:
-        exit(0)
+    setting_file = SETTING_FILE
+    if len(sys.argv) > 1:
+        setting_file = sys.argv[1]
+
     # load the settings file
-    settings = load_settings()
-    # test the function
-    for xml in settings.keys():
-        # replace_value_in_xml(os.path.join(XML_PATH, xml), settings[xml], os.path.join("test", xml))
-        replace_value_in_xml(os.path.join(XML_PATH, xml), settings[xml])
-    # test fail case
-    #replace_value_in_xml(xml, {"test": "test_value"})
+    settings = load_settings(setting_file)
+    change_pwd_to_script_root()
+    # replace settings in place
+    for config in settings.keys():
+        if config.endswith(".xml"):
+            replace_value_in_xml(os.path.join(XML_PATH, config), settings[config])
+        elif config.endswith(".py"):
+            replace_value_in_py(os.path.join(KEY_SETTINGS_PATH, config), settings[config])
+        else:
+            raise ValueError(f"Error: {config} is not a supported configuration")
+    print("Done")

--- a/py_scripts/ImageGeneration/inputs/settings.json
+++ b/py_scripts/ImageGeneration/inputs/settings.json
@@ -1,7 +1,0 @@
-{
-    "BootBlockAndHeader.xml":
-    {
-        "MC_CONFIG": "0x05",
-        "FIU1_CLK_DIVIDER": "7"
-    }
-}

--- a/py_scripts/ImageGeneration/test_config_replacer.py
+++ b/py_scripts/ImageGeneration/test_config_replacer.py
@@ -1,0 +1,124 @@
+import unittest
+import os
+import json
+import xml.etree.ElementTree as ET
+from config_replacer import load_settings, replace_value_in_xml, replace_value_in_py
+
+class ConfigReplacerTestCase(unittest.TestCase):
+    def setUp(self):
+        self.settings_file = "test_settings.json"
+        self.xml_file = "test.xml"
+        self.py_file = "test.py"
+        self.target_xml_file = "target_test.xml"
+        self.target_py_file = "target_test.py"
+
+    def tearDown(self):
+        if os.path.exists(self.settings_file):
+            os.remove(self.settings_file)
+        if os.path.exists(self.xml_file):
+            os.remove(self.xml_file)
+        if os.path.exists(self.py_file):
+            os.remove(self.py_file)
+        if os.path.exists(self.target_xml_file):
+            os.remove(self.target_xml_file)
+        if os.path.exists(self.target_py_file):
+            os.remove(self.target_py_file)
+
+    def test_load_settings(self):
+        # Create a test settings file
+        settings = {
+            "BootBlockAndHeader.xml": {
+                "MC_CONFIG": "0x05"
+            }
+        }
+        with open(self.settings_file, "w") as f:
+            json.dump(settings, f)
+
+        # Test loading the settings file
+        loaded_settings = load_settings(self.settings_file)
+        self.assertEqual(loaded_settings, settings)
+        # test invalid file
+        self.assertRaises(FileNotFoundError, load_settings, "invalid_file.json")
+        # test empty file
+        with open(self.settings_file, "w") as f:
+            f.write("")
+        self.assertEqual(load_settings(self.settings_file), {})
+        # test empty settings
+        with open(self.settings_file, "w") as f:
+            f.write("{}")
+        self.assertEqual(load_settings(self.settings_file), {})
+        # test invalid format
+        with open(self.settings_file, "w") as f:
+            f.write("invalid")
+        self.assertRaises(json.JSONDecodeError, load_settings, self.settings_file)
+
+    def test_replace_value_in_xml(self):
+        # Create a test XML file
+        root = ET.Element("Root")
+        element = ET.SubElement(root, "BinField")
+        name = ET.SubElement(element, "name")
+        name.text = "MC_CONFIG"
+        content = ET.SubElement(element, "content")
+        content.text = "0x01"
+        e2 = ET.SubElement(root, "BinField")
+        name2 = ET.SubElement(element, "name")
+        name2.text = "HOST_IF"
+        content2 = ET.SubElement(element, "content")
+        content2.text = "0x01"
+        tree = ET.ElementTree(root)
+        tree.write(self.xml_file)
+
+        # Define the replacement dictionary
+        replacements = {
+            "MC_CONFIG": "0x05"
+        }
+        not_exist_replacement = {
+            "MC_CONFIG1": "0x05"
+        }
+
+        # Test replacing values in the XML file
+        replace_value_in_xml(self.xml_file, replacements, self.target_xml_file)
+
+        # Verify the replaced values
+        target_tree = ET.parse(self.target_xml_file)
+        target_root = target_tree.getroot()
+        target_element = target_root.find("BinField")
+        target_content = target_element.find("content")
+        self.assertEqual(target_content.text, "0x05")
+        self.assertRaises(ValueError, replace_value_in_xml, self.xml_file, not_exist_replacement, self.target_xml_file)
+
+    def test_replace_value_in_py(self):
+        # Create a test Python file
+        content = """
+        Aaa = "0x01"
+        Bbb = "0x02"
+        Ccc = 123
+        """
+        with open(self.py_file, "w") as f:
+            f.write(content)
+
+        # Define the replacement dictionary
+        replacements = {
+            "Aaa": "\"0x05\""
+        }
+        # Error case
+        not_exist_replacement = {
+            "Ddd": "0x05"
+        }
+        case_replacement = {
+            "CCC": "0x05"
+        }
+
+        # Test replacing values in the Python file
+        replace_value_in_py(self.py_file, replacements, self.target_py_file)
+
+        # Verify the replaced values
+        with open(self.target_py_file, "r") as f:
+            target_content = f.read()
+        self.assertIn('Aaa = "0x05"', target_content)
+        self.assertRaises(ValueError, replace_value_in_py, self.py_file, not_exist_replacement, self.target_py_file)
+        self.assertRaises(ValueError, replace_value_in_py, self.py_file, case_replacement, self.target_py_file)
+        self.assertIn('Ccc = 123', target_content)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
1. Add new configuration type like key_setting_edit_me.py support
2. Remove settings.json due to we don't need change some settings by default.
3. Add unit test script for config_relpacer